### PR TITLE
Correctly handle basic authentication as required for token auth

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ function Client (options) {
   this.token = options.token;
   this.headers = {
     "content-type": "application/vnd.api+json",
-    "authorization": this.token,
+    "authorization": "Basic " + new Buffer(this.token).toString('base64'),
     "User-Agent": "Drip NodeJS Wrapper"
   }
 }

--- a/spec/lib/client_spec.js
+++ b/spec/lib/client_spec.js
@@ -3,13 +3,24 @@
 var Client = require('../../lib/index');
 
 describe('Client', function () {
-  it('should contain the correct headers', function () {
-    var client = new Client({ token: 'abc123' });
-    expect(client.token).toEqual('abc123');
-    expect(client.headers).toEqual({
-      "content-type": "application/vnd.api+json",
-      "authorization": 'abc123',
-      "User-Agent": "Drip NodeJS Wrapper"
-    });
+  var token = 'abc123';
+  it('should have token attribute', function () {
+    var client = new Client({ token: token });
+    expect(client.token).toEqual(token);
+  });
+
+  it('should add content-type header', function () {
+    var client = new Client({ token: token });
+    expect(client.headers["content-type"]).toEqual("application/vnd.api+json");
+  });
+
+  it('should add basic auth authorization header', function () {
+    var client = new Client({ token: token });
+    expect(client.headers.authorization).toEqual("Basic " + new Buffer(token).toString('base64'));
+  });
+
+  it('should add user-agent header', function () {
+    var client = new Client({ token: token });
+    expect(client.headers["User-Agent"]).toEqual("Drip NodeJS Wrapper");
   });
 });


### PR DESCRIPTION
The documentation instructs users to create a client instance using:

```javascript
var client = require('drip-nodejs')({ token: YOUR_API_KEY });
```

Which doesn't work. What the library actually needs is:

```javascript
var client = require('drip-nodejs')({ token: "Basic " + YOUR_BASE64_ENCODED_API_KEY });
```

This is a bit cumbersome so instead, we should handle the "Basic " concatenation and base64 encoding on the users behalf. This PR does that and adds tests for the functionality.