### PR TITLE
Add support for other token types

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ For private use and integrations, use your API Token found [here](https://www.ge
 
 `var client = require('drip-nodejs')({ token: YOUR_API_KEY });`
 
+For public integrations with an OAuth2 application registered with Drip, you'll need to specify the type of token you're passing (e.g. "Bearer"):
+
+`var client = require('drip-nodejs')({ token: YOUR_ACCESS_TOKEN, tokenType: TOKEN_TYPE });`
+
 For most API methods, you'll need your Drip Account ID found [here](https://www.getdrip.com/settings/general). Most client methods accept an account ID argument which allows interaction with any account maintained in your Drip account.
 
 ## Usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,10 +19,11 @@ function Client (options) {
     return new Client(options);
   }
 
+  var tokenType = options.tokenType || "Basic";
   this.token = options.token;
   this.headers = {
     "content-type": "application/vnd.api+json",
-    "authorization": "Basic " + new Buffer(this.token).toString('base64'),
+    "authorization": tokenType + " " + new Buffer(this.token).toString('base64'),
     "User-Agent": "Drip NodeJS Wrapper"
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,11 +19,15 @@ function Client (options) {
     return new Client(options);
   }
 
+  var token = this.token = options.token;
   var tokenType = options.tokenType || "Basic";
-  this.token = options.token;
+  if(tokenType === "Basic") {
+    // Encode the token before setting headers
+    token = new Buffer(this.token).toString('base64');
+  }
   this.headers = {
     "content-type": "application/vnd.api+json",
-    "authorization": tokenType + " " + new Buffer(this.token).toString('base64'),
+    "authorization": tokenType + " " + token,
     "User-Agent": "Drip NodeJS Wrapper"
   }
 }

--- a/spec/lib/client_spec.js
+++ b/spec/lib/client_spec.js
@@ -21,7 +21,7 @@ describe('Client', function () {
 
   it('should add bearer auth authorization header when tokenType is "Bearer"', function () {
     var client = new Client({ token: token, tokenType: "Bearer" });
-    expect(client.headers.authorization).toEqual("Bearer " + new Buffer(token).toString('base64'));
+    expect(client.headers.authorization).toEqual("Bearer " + token);
   });
 
   it('should add user-agent header', function () {

--- a/spec/lib/client_spec.js
+++ b/spec/lib/client_spec.js
@@ -14,9 +14,14 @@ describe('Client', function () {
     expect(client.headers["content-type"]).toEqual("application/vnd.api+json");
   });
 
-  it('should add basic auth authorization header', function () {
+  it('should add basic auth authorization header when no tokenType is specified', function () {
     var client = new Client({ token: token });
     expect(client.headers.authorization).toEqual("Basic " + new Buffer(token).toString('base64'));
+  });
+
+  it('should add bearer auth authorization header when tokenType is "Bearer"', function () {
+    var client = new Client({ token: token, tokenType: "Bearer" });
+    expect(client.headers.authorization).toEqual("Bearer " + new Buffer(token).toString('base64'));
   });
 
   it('should add user-agent header', function () {


### PR DESCRIPTION
Hey @samudary, great work on this, and thanks!

OAuth2 apps registered with Drip get access tokens, which need to be passed as "Bearer" tokens in the authorization header.

This tiny pull request adds support, a simple test, and a readme update for specifying `tokenType` along with `token`. (It defaults to "Basic", so it should be a non-breaking change.)